### PR TITLE
Update chat greeting and use conversation history

### DIFF
--- a/app/api/ai.py
+++ b/app/api/ai.py
@@ -32,12 +32,23 @@ class AIClient:
             f"AIClient initialized with model: {model} and endpoint: {self.api_url}"
         )
 
-    def create_response(self, user_message: str) -> str:
+    def create_response(self, user_message: str, history=None) -> str:
         """
         ユーザー全体の発言ログを要約する（興味・知識・スキルの傾向など）。
         """
 
+        history_text = ""
+        if history:
+            formatted = []
+            for m in history:
+                role = "ユーザー" if m.get("role") == "user" else "AI"
+                content = m.get("content", "")
+                formatted.append(f"{role}: {content}")
+            history_text = "\n".join(formatted)
+
         prompt = self.prompt_template.format(user_message=user_message)
+        if history_text:
+            prompt = f"{history_text}\n{prompt}"
         logger.info(f"Prompt sent to LLM: {prompt}")
 
         try:

--- a/app/api/main.py
+++ b/app/api/main.py
@@ -23,7 +23,8 @@ async def post_usermessage(request: Request) -> str:
    
     ai_generator = AIClient()
     message = body.get("message", "")
-    ai_response = ai_generator.create_response(message)
+    history = body.get("history", [])
+    ai_response = ai_generator.create_response(message, history)
     logger.info(f"AI response: {ai_response}")
     repo = DBClient()
     repo.insert_message("me",message)

--- a/app/ui/ui.py
+++ b/app/ui/ui.py
@@ -19,9 +19,9 @@ class ChatUI:
         self.audio_output = AudioOutput()
 
     @staticmethod
-    def call_api(text: str) -> str:
+    def call_api(text: str, history) -> str:
         try:
-            resp = requests.post(API_URL, json={"message": text})
+            resp = requests.post(API_URL, json={"message": text, "history": history})
             resp.raise_for_status()
             return resp.text.strip()
         except Exception as e:
@@ -41,7 +41,7 @@ class ChatUI:
 
         if "messages" not in st.session_state:
             st.session_state.messages = [
-                {"role": "assistant", "content": "こんにちは！チャットへようこそ。"}
+                {"role": "assistant", "content": "何かございましたか？"}
             ]
         if "voice_processed" not in st.session_state:
             st.session_state.voice_processed = False
@@ -51,7 +51,7 @@ class ChatUI:
             if text and not st.session_state.voice_processed:
                 st.session_state.voice_processed = True
                 st.session_state.messages.append({"role": "user", "content": text})
-                reply = self.call_api(text)
+                reply = self.call_api(text, st.session_state.messages)
                 st.session_state.messages.append({"role": "assistant", "content": reply})
                 st.session_state.speak_text = reply
                 self._rerun()


### PR DESCRIPTION
## Summary
- adjust greeting text in Streamlit UI
- send conversation history to backend when requesting an AI reply
- update FastAPI endpoint to pass history to AI client
- prepend previous messages when building prompts for the LLM

## Testing
- `python -m py_compile app/ui/ui.py app/api/main.py app/api/ai.py`
- `./api_test.sh` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_6843d1dedc5c83318e413c1214631f22