### PR TITLE
Append rating modal

### DIFF
--- a/app/api/main.py
+++ b/app/api/main.py
@@ -26,6 +26,13 @@ async def post_usermessage(request: Request) -> str:
     history = body.get("history", [])
     ai_response = ai_generator.create_response(message, history)
     logger.info(f"AI response: {ai_response}")
+
+    # Add prompt for continuing or ending the conversation
+    suffix = (
+        "お話を続ける場合はマイクを押してお話しください。" \
+        "お話を終える場合は\"評価\"ボタンを押して会話を終了してください"
+    )
+    ai_response = f"{ai_response} {suffix}"
     repo = DBClient()
     repo.insert_message("me",message)
     repo.insert_message("ai",ai_response)

--- a/app/ui/audio_output.py
+++ b/app/ui/audio_output.py
@@ -36,6 +36,10 @@ class AudioOutput:
     def speak(self, text: str) -> None:
         if not text:
             return
+
+        # Remove newline characters to avoid them being spoken aloud
+        text = text.replace("\n", " ")
+
         try:
             audio = self._synthesize(text)
             encoded = base64.b64encode(audio).decode("utf-8")

--- a/app/ui/ui.py
+++ b/app/ui/ui.py
@@ -41,7 +41,7 @@ class ChatUI:
 
         if "messages" not in st.session_state:
             st.session_state.messages = [
-                {"role": "assistant", "content": "何かございましたか？"}
+                {"role": "assistant", "content": "何かございましたか？マイクを押してお話ください。"}
             ]
         if "voice_processed" not in st.session_state:
             st.session_state.voice_processed = False

--- a/app/ui/ui.py
+++ b/app/ui/ui.py
@@ -69,15 +69,10 @@ class ChatUI:
         with mic_col:
             audio = self.voice.record_audio()
         with rate_col:
-            if st.button("評価"):
-                st.session_state.show_rating = True
-
-        if st.session_state.get("show_rating"):
-            with st.modal("評価"):
+            with st.popover("評価"):
                 st.markdown("★5")
                 st.markdown("神対応でした。")
-                if st.button("OK", key="rate_ok"):
-                    st.session_state.show_rating = False
+                st.button("OK", key="rate_ok")
 
         if len(audio) > 0:
             st.session_state.last_audio = audio

--- a/app/ui/ui.py
+++ b/app/ui/ui.py
@@ -65,7 +65,19 @@ class ChatUI:
         if "speak_text" in st.session_state:
             self.audio_output.speak(st.session_state.pop("speak_text"))
 
-        audio = self.voice.record_audio()
+        mic_col, rate_col = st.columns([3, 1])
+        with mic_col:
+            audio = self.voice.record_audio()
+        with rate_col:
+            if st.button("評価"):
+                st.session_state.show_rating = True
+
+        if st.session_state.get("show_rating"):
+            with st.modal("評価"):
+                st.markdown("★5")
+                st.markdown("神対応でした。")
+                if st.button("OK", key="rate_ok"):
+                    st.session_state.show_rating = False
 
         if len(audio) > 0:
             st.session_state.last_audio = audio


### PR DESCRIPTION
## Summary
- add a "評価" button next to the microphone
- display a modal with ★5 and "神対応でした。" when pressed
- keep newline stripping and end-of-chat instructions

## Testing
- `python -m py_compile app/api/main.py app/ui/audio_output.py app/ui/ui.py app/ui/voice_input.py`


------
https://chatgpt.com/codex/tasks/task_e_6843d62f774c8331aeb53eb84a6332be