### PR TITLE
Use GPT-4o via OpenAI API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and fill in your OpenAI API key
+OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.env

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,0 +1,6 @@
+FROM python:3.9
+WORKDIR /app
+COPY requirements.api.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "app.api.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"] 

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,0 +1,17 @@
+FROM python:3.9
+WORKDIR /app
+
+# Install system dependencies required for audio processing
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.ui.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . ./
+
+CMD ["streamlit", "run", "app/ui/ui.py", \
+     "--server.port", "5000", \
+     "--server.address", "0.0.0.0", \
+     "--server.headless", "true"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,163 @@
-# all-japan-ai-hackathon-2025-fukuoka
-全日本AIハッカソン 2025の九州大会用
+# AI Agent 開発講座（音声入出力編）
+
+このプロジェクトは、AIエージェントと対話するためのWebアプリケーションです。FastAPIバックエンドとStreamlitフロントエンドで構成され、ブラウザで音声入力と音声出力が利用できます。
+
+## 学習内容
+
+- Streamlitを使用したWebフロントエンドの構築
+- FastAPIバックエンドとの連携
+- Webインターフェースの設計と実装
+- ユーザーとAIの対話機能の実装
+- データベースとの連携
+- 音声入力と音声出力機能の実装
+
+## プロジェクト構成
+
+```
+.
+├── app/
+│   ├── api/                    # FastAPIバックエンド
+│   │   ├── main.py            # メインAPIエンドポイント
+│   │   ├── ai.py              # AI応答生成ロジック
+│   │   └── db.py              # メッセージ保存ロジック
+│   └── ui/                    # Streamlitフロントエンド
+│       ├── ui.py              # UIアプリケーション
+│       ├── voice_input.py     # 音声入力機能
+│       └── audio_output.py    # 音声出力機能
+├── voicebox/                  # VOICEVOX エンジンコンテナ
+├── mysql/                     # MySQLデータベース関連
+│   └── db/user_messages.sql   # テーブル定義(DDL)
+├── config.py                  # 設定ファイル
+├── requirements.api.txt       # API依存関係
+├── requirements.ui.txt        # UI依存関係
+├── Dockerfile.api             # API用Dockerfile
+├── Dockerfile.ui              # UI用Dockerfile
+├── docker-compose.yaml        # Docker Compose設定
+├── api_test.sh                # APIテスト用スクリプト
+└── db_connect.sh              # DB接続確認用スクリプト
+```
+
+## 主要なコンポーネント
+
+- FastAPIバックエンド: ユーザーメッセージの処理とAI応答の生成
+- Streamlitフロントエンド: ユーザーインターフェースの提供
+- データベース連携: 会話履歴の保存と取得
+- 音声入出力: マイク録音と VOICEVOX による音声生成
+
+## 実装のポイント
+
+### バックエンド（FastAPI）
+- APIエンドポイントの定義
+- データベース操作の実装
+- AI応答生成ロジックの実装
+
+### フロントエンド（Streamlit）
+- ユーザーインターフェースの実装
+- APIとの通信処理
+- セッション状態を使用した会話履歴の管理
+ - OpenAI Whisper API を利用した音声認識
+- 音声認識結果とLLMへ送信するプロンプトをログ出力
+ - AI応答を VOICEVOX で音声生成して再生
+
+## セットアップ
+
+### 前提条件
+
+- Python 3.9以上
+- 必要なパッケージ（requirements.txtに記載）
+
+### セットアップ手順
+
+1. **リポジトリのクローン**
+    ```bash
+    git clone -b voice https://github.com/dx-junkyard/ai-agent-playground.git
+    cd ai-agent-playground
+    ```
+
+2. **環境構築**
+    - 必要な環境変数を設定
+    - 依存パッケージのインストール
+
+3. **アプリケーションの起動**
+    ```bash
+    # Linux/Mac環境
+    docker compose up
+    ```
+
+4. **アプリケーションにアクセス**
+    - UI: http://localhost:8080
+    - API: http://localhost:8086
+    - VOICEVOX: http://localhost:50021
+
+## 使い方
+
+### Webインターフェース
+
+1. ブラウザで http://localhost:8080 にアクセス
+2. テキスト入力欄にメッセージを入力
+3. 「送信」ボタンでAIと対話
+4. 🎤 ボタンを押すとブラウザで録音して送信できます
+5. AIの応答は自動で音声再生されます
+6. 会話履歴は画面上に表示されます
+
+#### 音声入力を利用するには
+
+1. `.env.example` をコピーして `.env` を作成し、`OPENAI_API_KEY` を設定します
+2. ブラウザがマイクへのアクセスを求めたら許可してください。録音はブラウザ側で行われるため、Dockerコンテナからホストのマイクを参照する必要はありません
+3. 音声の変換には `ffmpeg` が必要です。Docker イメージでは自動でインストールされます。ローカル環境で実行する場合は `ffmpeg` をインストールしてください
+4. 音声認識で得られたテキストはログに出力されます
+
+#### 音声出力について
+VOICEVOX コンテナを利用して音声を生成し、ブラウザ上で再生します。
+`docker compose up` を実行すると自動で起動します。
+
+### APIの直接利用
+
+#### メッセージの送信
+
+```bash
+curl http://localhost:8086/api/v1/user-message \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": "こんにちは！"
+  }'
+```
+
+#### 履歴の取得
+
+```bash
+curl 'http://localhost:8086/api/v1/user-messages?user_id=me&limit=10'
+```
+
+## 開発
+
+### バックエンド（FastAPI）
+
+バックエンドはFastAPIを使用して実装されており、以下のエンドポイントを提供します：
+
+- `POST /api/v1/user-message`: ユーザーメッセージを処理し、AI応答を返す
+- `GET /api/v1/user-messages`: 過去のメッセージ履歴を取得
+- 送信するプロンプトをログに記録してデバッグ可能
+
+### フロントエンド（Streamlit）
+
+フロントエンドはStreamlitを使用して実装されており、以下の機能を提供します：
+
+- ユーザーメッセージの入力
+- AI応答の表示
+- メッセージ履歴の表示
+- マイク入力と音声読み上げ
+
+このUIは、以前HTMLサンプルとして示したチャット画面のレイアウトをStreamlit上で再現しています。
+
+## 拡張アイデア
+
+- ユーザー認証の追加
+- 複数のAIモデル切り替え機能
+- メッセージの検索機能
+- 会話履歴のエクスポート機能
+
+## ライセンス
+
+このプロジェクトは[MITライセンス](LICENSE)の下で公開されています。

--- a/api_test.sh
+++ b/api_test.sh
@@ -1,0 +1,6 @@
+curl http://localhost:8086/api/v1/user-message \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": "週末はコーヒーを淹れて、その香りをたのしみながら読書をします。あなたは週末何をしますか？"
+  }'

--- a/app/api/ai.py
+++ b/app/api/ai.py
@@ -1,0 +1,54 @@
+import os
+import requests
+import logging
+from config import AI_MODEL, AI_URL
+
+# ログ設定（必要に応じてレベルを DEBUG に変更可能）
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s"
+)
+
+logger = logging.getLogger(__name__)
+class AIClient:
+    """
+    ユーザーの発言に対して、会話を盛り上げる返答を生成するクラス。
+    """
+
+    def __init__(self, model: str = AI_MODEL, endpoint: str = AI_URL):
+        self.model = model
+        self.api_url = endpoint
+        self.api_key = os.getenv("OPENAI_API_KEY", "")
+        logging.info(
+            f"AIClient initialized with model: {model} and endpoint: {self.api_url}"
+        )
+
+    def create_response(self, user_message: str) -> str:
+        """
+        ユーザー全体の発言ログを要約する（興味・知識・スキルの傾向など）。
+        """
+
+        prompt = f"""以下はカスタマーサポート担当者とユーザーの会話です。丁寧な敬語でユーザーの問題解決をサポートする返答をしてください。
+    【ユーザー発言】:
+    {user_message}
+    """
+        logger.info(f"Prompt sent to LLM: {prompt}")
+
+        try:
+            headers = {
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            }
+            payload = {
+                "model": self.model,
+                "messages": [
+                    {"role": "user", "content": prompt},
+                ],
+            }
+            response = requests.post(self.api_url, json=payload, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+            return data.get("choices", [{}])[0].get("message", {}).get("content", "").strip()
+        except Exception as e:
+            logging.error(f"[✗] 返答生成失敗: {e}")
+            return "すみません、AIが回答できませんでした。"

--- a/app/api/db.py
+++ b/app/api/db.py
@@ -1,0 +1,60 @@
+import mysql.connector
+from config import DB_HOST, DB_USER, DB_PASSWORD, DB_NAME, DB_PORT
+
+class DBClient:
+    def __init__(self):
+        self.config = {
+            'host': DB_HOST,
+            'user': DB_USER,
+            'password': DB_PASSWORD,
+            'database': DB_NAME,
+            'port': DB_PORT,
+            'charset': 'utf8mb4'
+        }
+
+    def insert_message(self, user_id, message):
+        try:
+            conn = mysql.connector.connect(**self.config)
+            cursor = conn.cursor()
+
+            query = """
+                INSERT INTO user_messages (user_id, message)
+                VALUES (%s, %s)
+            """
+            values = (user_id, message)
+            cursor.execute(query, values)
+            conn.commit()
+
+            print(f"[✓] Inserted user_messages for user_id={user_id}")
+
+        except mysql.connector.Error as err:
+            print(f"[✗] MySQL Error: {err}")
+        finally:
+            if cursor:
+                cursor.close()
+            if conn:
+                conn.close()
+
+    def get_user_messages(self, user_id, limit=10):
+        conn = None
+        cursor = None
+        try:
+            conn = mysql.connector.connect(**self.config)
+            cursor = conn.cursor(dictionary=True)
+            query = """
+                SELECT user_id, message
+                FROM user_messages
+                WHERE user_id = %s
+                ORDER BY id DESC
+                LIMIT %s
+            """
+            cursor.execute(query, (user_id, limit))
+            messages = cursor.fetchall()
+            return messages
+        except mysql.connector.Error as err:
+            print(f"[✗] MySQL Error: {err}")
+            return []
+        finally:
+            if cursor: cursor.close()
+            if conn: conn.close()
+

--- a/app/api/main.py
+++ b/app/api/main.py
@@ -1,0 +1,42 @@
+import requests
+from fastapi import FastAPI, Request, HTTPException, Query
+from typing import Dict, List
+import logging
+
+# config.pyからトークンやAPIエンドポイントをインポート
+from app.api.ai import AIClient
+from app.api.db import DBClient
+
+app = FastAPI()
+
+# ログ設定
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# LINEのWebhookエンドポイント
+@app.post("/api/v1/user-message")
+async def post_usermessage(request: Request) -> str:
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON")
+   
+    ai_generator = AIClient()
+    message = body.get("message", "")
+    ai_response = ai_generator.create_response(message)
+    logger.info(f"AI response: {ai_response}")
+    repo = DBClient()
+    repo.insert_message("me",message)
+    repo.insert_message("ai",ai_response)
+    return ai_response
+
+@app.get("/api/v1/user-messages")
+async def get_user_messages(user_id: str = Query(..., description="ユーザーID"), limit: int = Query(10, ge=1, le=100, description="取得件数")) -> List[Dict]:
+    repo = DBClient()
+    messages = repo.get_user_messages(user_id=user_id, limit=limit)
+    return messages
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)
+

--- a/app/ui/audio_output.py
+++ b/app/ui/audio_output.py
@@ -1,0 +1,35 @@
+import os
+import requests
+import streamlit as st
+
+
+class AudioOutput:
+    """Generate speech using VOICEVOX (VoiceBox) engine and play it."""
+
+    def __init__(self, base_url: str = None, speaker: int = 1) -> None:
+        self.base_url = base_url or os.environ.get("VOICEBOX_URL", "http://voicebox:50021")
+        self.speaker = speaker
+
+    def _synthesize(self, text: str) -> bytes:
+        """Request VOICEVOX to synthesize speech and return WAV bytes."""
+        query = requests.post(
+            f"{self.base_url}/audio_query",
+            params={"speaker": self.speaker, "text": text},
+        )
+        query.raise_for_status()
+        synthesis = requests.post(
+            f"{self.base_url}/synthesis",
+            params={"speaker": self.speaker},
+            json=query.json(),
+        )
+        synthesis.raise_for_status()
+        return synthesis.content
+
+    def speak(self, text: str) -> None:
+        if not text:
+            return
+        try:
+            audio = self._synthesize(text)
+            st.audio(audio, format="audio/wav")
+        except Exception as e:
+            st.error(f"音声生成失敗: {e}")

--- a/app/ui/ui.py
+++ b/app/ui/ui.py
@@ -1,0 +1,92 @@
+import logging
+import os
+import requests
+import streamlit as st
+
+from voice_input import VoiceInput
+from audio_output import AudioOutput
+
+logger = logging.getLogger(__name__)
+
+API_URL = os.environ.get("API_URL", "http://api:8000/api/v1/user-message")
+
+
+class ChatUI:
+    """Main chat UI handling text and voice input."""
+
+    def __init__(self):
+        self.voice = VoiceInput()
+        self.audio_output = AudioOutput()
+
+    @staticmethod
+    def call_api(text: str) -> str:
+        try:
+            resp = requests.post(API_URL, json={"message": text})
+            resp.raise_for_status()
+            return resp.text.strip()
+        except Exception as e:
+            st.error(f"送信エラー: {e}")
+            return "エラーが発生しました"
+
+    def _rerun(self):
+        """Rerun Streamlit script with backward compatibility."""
+        if hasattr(st, "experimental_rerun"):
+            st.experimental_rerun()
+        else:
+            st.rerun()
+
+    def run(self):
+        st.set_page_config(page_title="AI チャットアプリ", page_icon="🤖")
+
+        if "messages" not in st.session_state:
+            st.session_state.messages = [
+                {"role": "assistant", "content": "こんにちは！チャットへようこそ。"}
+            ]
+        if "voice_processed" not in st.session_state:
+            st.session_state.voice_processed = False
+
+        if "last_audio" in st.session_state:
+            text = self.voice.transcribe(st.session_state.pop("last_audio"))
+            if text and not st.session_state.voice_processed:
+                st.session_state.voice_processed = True
+                st.session_state.messages.append({"role": "user", "content": text})
+                reply = self.call_api(text)
+                st.session_state.messages.append({"role": "assistant", "content": reply})
+                st.session_state.speak_text = reply
+                self._rerun()
+            elif not text:
+                st.session_state.voice_processed = False
+
+        for m in st.session_state.messages:
+            with st.chat_message("user" if m["role"] == "user" else "ai"):
+                st.markdown(m["content"])
+
+        if "speak_text" in st.session_state:
+            self.audio_output.speak(st.session_state.pop("speak_text"))
+
+        prompt = st.chat_input("メッセージを入力...")
+        audio = self.voice.record_audio()
+
+        if prompt:
+            st.session_state.messages.append({"role": "user", "content": prompt})
+            with st.chat_message("user"):
+                st.markdown(prompt)
+
+            reply = self.call_api(prompt)
+            st.session_state.messages.append({"role": "assistant", "content": reply})
+            with st.chat_message("ai"):
+                st.markdown(reply)
+            st.session_state.speak_text = reply
+
+        if len(audio) > 0:
+            st.session_state.last_audio = audio
+            st.session_state.voice_processed = False
+            self._rerun()
+
+
+def main():
+    ChatUI().run()
+
+
+if __name__ == "__main__":
+    main()

--- a/app/ui/voice_input.py
+++ b/app/ui/voice_input.py
@@ -1,0 +1,72 @@
+import logging
+import os
+import tempfile
+
+import streamlit as st
+from audiorecorder import audiorecorder
+from dotenv import load_dotenv
+from openai import OpenAI
+from pydub import AudioSegment
+
+logger = logging.getLogger(__name__)
+
+# Load environment variables from .env if available
+load_dotenv()
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY", ""))
+
+
+class VoiceInput:
+    """Handle voice recording and speech recognition using Whisper API."""
+
+    @staticmethod
+    def record_audio() -> AudioSegment:
+        """Render the audio recorder widget and return the recorded segment."""
+        try:
+            audio = audiorecorder(
+                "🎤",
+                "録音中",
+                start_style={
+                    "background-color": "#eee",
+                    "border": "1px solid #ccc",
+                    "border-radius": "50%",
+                },
+                stop_style={"background-color": "#fdd"},
+                key="voice_recorder",
+            )
+        except FileNotFoundError:
+            st.error("ffmpeg が見つかりません。Docker イメージを再ビルドしてください")
+            return AudioSegment.empty()
+        except Exception as e:
+            st.error(f"録音エラー: {e}")
+            return AudioSegment.empty()
+        return audio
+
+    @staticmethod
+    def transcribe(audio: AudioSegment) -> str:
+        """Transcribe a recorded AudioSegment using OpenAI Whisper."""
+        if len(audio) == 0:
+            return ""
+        audio = audio.set_channels(1).set_frame_rate(16000)
+        with tempfile.NamedTemporaryFile(suffix=".wav") as tmp:
+            audio.export(tmp.name, format="wav")
+            tmp.seek(0)
+            with st.spinner("音声認識中..."):
+                try:
+                    with open(tmp.name, "rb") as f:
+                        result = client.audio.transcriptions.create(
+                            model="whisper-1",
+                            file=f,
+                            language="ja",
+                        )
+                    text = result.text
+                except Exception as e:
+                    st.error(f"音声認識失敗: {e}")
+                    logger.error("Whisper API error: %s", e)
+                    return ""
+        logger.info(f"Recognized voice text: {text}")
+        return text.strip()
+
+    def recognize_voice(self) -> str:
+        """Record audio via widget then transcribe it."""
+        audio = self.record_audio()
+        return self.transcribe(audio)

--- a/config.py
+++ b/config.py
@@ -1,0 +1,24 @@
+# config.py
+# ここに設定を記載します
+
+# LINEチャネルアクセストークン（LINE Developersで発行されたトークン）
+LINE_CHANNEL_ACCESS_TOKEN = "basicコースでは使いません"
+
+AI_MODEL = "gpt-4o"
+
+# OpenAI chat completions endpoint
+AI_URL = "https://api.openai.com/v1/chat/completions"
+
+DB_HOST = "db"
+
+DB_USER = "me"
+
+DB_PASSWORD = "me"
+
+DB_NAME = "mydb"
+
+DB_PORT = 3306
+
+# VOICEBOXエンジンのURL
+VOICEBOX_URL = "http://voicebox:50021"
+

--- a/db_connect.sh
+++ b/db_connect.sh
@@ -1,0 +1,7 @@
+docker exec -it my_mysql mysql --default-character-set=utf8 -u me -p mydb
+# password : me
+# 
+# 接続後は、以下のコマンドでDBの状態を確認する
+# ---
+# show tables;
+# select * from user_messages;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,38 @@
+version: '3'
+
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+    ports:
+      - "8086:8000"
+    volumes:
+      - .:/app
+
+  ui:
+    build:
+      context: .
+      dockerfile: Dockerfile.ui
+    ports:
+      - "8080:5000"
+    volumes:
+      - .:/app
+
+  voicebox:
+    image: voicevox/voicevox_engine:cpu-ubuntu20.04-latest
+    ports:
+      - "50021:50021"
+    restart: unless-stopped
+
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: mydb
+      MYSQL_USER: me
+      MYSQL_PASSWORD: me
+    ports:
+      - "3306:3306"
+    volumes:
+      - ./mysql/db:/docker-entrypoint-initdb.d

--- a/mysql/db/user_messages.sql
+++ b/mysql/db/user_messages.sql
@@ -1,0 +1,6 @@
+CREATE TABLE user_messages (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    user_id VARCHAR(255) NOT NULL,
+    message TEXT,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -1,0 +1,8 @@
+[mysqld]
+character-set-server=utf8
+
+[mysql]
+default-character-set=utf8
+
+[client]
+default-character-set=utf8

--- a/ollama_test.sh
+++ b/ollama_test.sh
@@ -1,0 +1,8 @@
+curl http://localhost:11434/api/generate \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "schroneko/llama-3.1-swallow-8b-instruct-v0.1:latest",
+    "prompt": "日本の歴史を縄文時代から簡単におしえてください",
+    "stream": false
+  }'

--- a/requirements.api.txt
+++ b/requirements.api.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+requests
+mysql-connector-python 

--- a/requirements.ui.txt
+++ b/requirements.ui.txt
@@ -1,0 +1,6 @@
+streamlit>=1.25.0
+requests>=2.28.0
+openai>=1.3.0
+python-dotenv>=1.0.0
+streamlit-audiorecorder>=0.0.6
+pydub>=0.25.1


### PR DESCRIPTION
## Summary
- configure `AI_MODEL` and `AI_URL` for OpenAI
- send prompts to OpenAI's chat completion endpoint with API key

## Testing
- `python -m py_compile app/api/ai.py`
- `python -m py_compile app/api/main.py app/api/db.py app/ui/ui.py app/ui/voice_input.py app/ui/audio_output.py`
- `pytest -q`
- `env -u HTTP_PROXY -u HTTPS_PROXY python - <<'EOF'
import openai
print('openai version', openai.__version__)
client = openai.OpenAI(api_key='sk-test')
try:
    client.models.list()
except Exception as e:
    print('error type', type(e).__name__)
    print('error message', str(e).splitlines()[0])
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6843a66dc3988329878a4f687f97e6af